### PR TITLE
Compare combined data to saved JPEG

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -979,8 +979,8 @@ class TestFileJpeg:
         for marker, in_tables, in_image in expectations:
             assert (marker in tables.getvalue()) == in_tables
             assert (marker in image.getvalue()) == in_image
-        im2 = Image.open(BytesIO(tables.getvalue() + image.getvalue()))
-        assert_image_similar(im, im2, 17)
+        with Image.open(BytesIO(tables.getvalue() + image.getvalue())) as im2:
+            assert_image_similar(im, im2, 17)
 
     def test_repr_jpeg(self):
         im = hopper()

--- a/src/libImaging/JpegEncode.c
+++ b/src/libImaging/JpegEncode.c
@@ -218,9 +218,9 @@ ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
             }
             switch (context->streamtype) {
                 case 1:
-                    /* tables only -- not yet implemented */
-                    state->errcode = IMAGING_CODEC_CONFIG;
-                    return -1;
+                    /* tables only */
+                    jpeg_write_tables(&context->cinfo);
+                    goto cleanup;
                 case 2:
                     /* image only */
                     jpeg_suppress_tables(&context->cinfo, TRUE);
@@ -316,6 +316,7 @@ ImagingJpegEncode(Imaging im, ImagingCodecState state, UINT8 *buf, int bytes) {
             }
             jpeg_finish_compress(&context->cinfo);
 
+cleanup:
             /* Clean up */
             if (context->comment) {
                 free(context->comment);


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/7491

1. As per https://pillow.readthedocs.io/en/stable/releasenotes/7.0.0.html#image-del, images should not be implicitly closed, so I've added a context manager to the opened image.
2. Rather than asserting that the combined image is similar to the original image, I've saved the original image as a separate JPEG, and asserted that it is equal to the combined version. That seems like a more interesting check to me.

I've also restructured the test code, which you may have different thoughts about, so feel free to only use part of this.